### PR TITLE
Dev 1885: sandbox-simulations schemas + GET customer sole prop variant

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -913,6 +913,7 @@ paths:
                   - $ref: '#/components/schemas/UnverifiedCustomer'
                   - $ref: '#/components/schemas/ReceiveOnlyCustomer'
                   - $ref: '#/components/schemas/VerifiedPersonalCustomer'
+                  - $ref: '#/components/schemas/VerifiedSolePropCustomer'
                   - $ref: '#/components/schemas/VerifiedBusinessCustomer'
         '403':
           description: forbidden
@@ -8544,11 +8545,17 @@ paths:
     post:
       tags:
         - sandbox simulations
-      summary: Simulate bank transfer processing (Sandbox only)
+      summary: Sandbox simulations (bank transfer processing or VAN transfers)
       description: |
-        Triggers processing for the last 500 bank transfers on the authorized application or Sandbox account. This endpoint is only available in the Sandbox environment. It will process or fail pending bank-to-bank transactions (including both sides of a transfer when applicable) and initiated micro-deposits. If webhooks are configured, corresponding events will be delivered.
+        Sandbox-only endpoint with two modes:
 
-        If a bank-to-bank transaction is initiated between two users, call this endpoint twice to process both the debit and credit sides.
+        **Simulate bank transfer processing** — Omit the body or send an empty JSON object. Processes or fails
+        the last 500 bank transfers on the authorized application or Sandbox account (and initiated micro-deposits).
+        If webhooks are configured, events are delivered. If a bank-to-bank transaction involves two users,
+        call this twice to process debit and credit sides. Returns **200** with a HAL document including `total`.
+
+        **Simulate VAN (virtual) transfers** — Send a JSON body with `type` set to `virtual` and a `transfers`
+        array (up to 10 items). External transfers are created and processed immediately. Returns **202 Accepted**.
       operationId: simulateBankTransferProcessing
       x-speakeasy-name-override: simulate
       x-codeSamples:
@@ -8562,18 +8569,33 @@ paths:
         - $ref: '#/components/parameters/Accept'
       requestBody:
         required: false
-        description: Optional JSON body. Typically empty; presence of body is not required.
+        description: |
+          Optional. Use an empty object (or omit the body) for bank transfer processing. For VAN simulation,
+          send `type`: `virtual` and a `transfers` array (see schema).
         content:
           application/vnd.dwolla.v1.hal+json:
             schema:
-              type: object
+              $ref: '#/components/schemas/SandboxSimulationRequest'
       responses:
         '200':
-          description: Simulation executed. Pending bank transfers and micro-deposits were processed or failed.
+          description: |
+            Bank transfer processing simulation completed. Pending bank transfers and micro-deposits were
+            processed or failed.
           content:
             application/vnd.dwolla.v1.hal+json:
               schema:
-                type: object
+                $ref: '#/components/schemas/SandboxSimulationBankProcessingResponse'
+              example:
+                _links:
+                  self:
+                    href: https://api-sandbox.dwolla.com/sandbox-simulations
+                    type: application/vnd.dwolla.v1.hal+json
+                    resource-type: sandbox-simulation
+                total: 8
+        '202':
+          description: |
+            Accepted. Virtual (VAN) transfer simulation: requested transfers were accepted for immediate
+            processing in Sandbox.
         '401':
           description: unauthorized
           content:
@@ -15934,6 +15956,93 @@ components:
           type: integer
           format: int32
           example: 1
+    SandboxSimulationBankProcessingRequest:
+      title: SandboxSimulationBankProcessingRequest
+      description: |
+        Omit the body, send JSON null, or an empty JSON object. Triggers processing (or failure) for the last
+        500 bank transfers on the authorized application or Sandbox account, and initiated micro-deposits.
+        Successful response is 200 with a HAL body including total.
+      oneOf:
+        - title: SandboxSimulationBankProcessingEmptyObject
+          description: Empty JSON object.
+          type: object
+          additionalProperties: false
+        - type: 'null'
+          description: JSON null body (uncommon).
+    SandboxSimulationVirtualTransferItem:
+      title: SandboxSimulationVirtualTransferItem
+      description: One simulated external (VAN) transfer in a sandbox-simulations request.
+      type: object
+      required:
+        - _link
+        - amount
+      properties:
+        _link:
+          type: object
+          description: Link wrapper for the destination funding source (Dwolla HAL-style single link).
+          required:
+            - destination
+          properties:
+            destination:
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+                  format: uri
+                  example: https://api-sandbox.dwolla.com/funding-sources/5880e310-675a-4ce3-87d9-a475cc565e09
+        amount:
+          $ref: '#/components/schemas/TransferAmount'
+    SandboxSimulationVirtualRequest:
+      title: SandboxSimulationVirtualRequest
+      description: |
+        Simulate Virtual Account Number (VAN) / external transfers in Sandbox. Up to 10 transfers per request;
+        transfers are created and processed immediately. Successful response is 202 Accepted.
+      type: object
+      required:
+        - type
+        - transfers
+      properties:
+        type:
+          type: string
+          const: virtual
+          description: Must be set to virtual for VAN transfer simulation.
+        transfers:
+          type: array
+          description: Transfers to simulate (max 10 per request).
+          minItems: 1
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/SandboxSimulationVirtualTransferItem'
+    SandboxSimulationRequest:
+      title: SandboxSimulationRequest
+      description: |
+        Bank transfer processing (empty body) or VAN transfer simulation (type virtual + transfers).
+        Use an empty object or omit the body for bank processing; use a virtual payload for VAN simulation.
+      oneOf:
+        - $ref: '#/components/schemas/SandboxSimulationBankProcessingRequest'
+        - $ref: '#/components/schemas/SandboxSimulationVirtualRequest'
+    SandboxSimulationBankProcessingResponse:
+      title: SandboxSimulationBankProcessingResponse
+      description: Response when simulating bank transfer processing (200 OK).
+      type: object
+      required:
+        - _links
+        - total
+      properties:
+        total:
+          type: integer
+          format: int32
+          example: 8
+          description: Count of bank transfers (and related items) affected by the simulation run.
+        _links:
+          type: object
+          required:
+            - self
+          properties:
+            self:
+              $ref: '#/components/schemas/HalLink'
     ExchangePartner:
       title: ExchangePartner
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -8576,9 +8576,8 @@ paths:
       requestBody:
         required: false
         description: |
-          Optional. Use an empty object (or omit the body) for bank transfer processing. For VAN simulation,
-          send `type`: `virtual` and a `transfers` array. For verification directives, send `type`:
-          `customer-verification`, `_links.customer`, and `errorCode` (see schema).
+          Optional. For bank transfer processing, omit the body or send `{}`. For VAN simulation, send `type`: `virtual` and a `transfers` array. For verification
+          directives, send `type`: `customer-verification`, `_links.customer`, and `errorCode` (see schema).
         content:
           application/vnd.dwolla.v1.hal+json:
             schema:
@@ -8617,6 +8616,13 @@ paths:
           description: |
             Accepted. Virtual (VAN) transfer simulation: requested transfers were accepted for immediate
             processing in Sandbox.
+        '400':
+          description: |
+            Bad Request.
+          content:
+            application/vnd.dwolla.v1.hal+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
         '401':
           description: unauthorized
           content:
@@ -16066,22 +16072,17 @@ components:
     SandboxSimulationBankProcessingRequest:
       title: SandboxSimulationBankProcessingRequest
       description: |
-        Omit the body, send JSON null, or an empty JSON object. Triggers processing (or failure) for the last
+        Omit the request body or send an empty JSON object (`{}`). Triggers processing (or failure) for the last
         500 bank transfers on the authorized application or Sandbox account, and initiated micro-deposits.
         Successful response is 200 with a HAL body including total.
-      oneOf:
-        - title: SandboxSimulationBankProcessingEmptyObject
-          description: Empty JSON object.
-          type: object
-          additionalProperties: false
-        - type: 'null'
-          description: JSON null body (uncommon).
+      type: object
+      additionalProperties: false
     SandboxSimulationRequest:
       title: SandboxSimulationRequest
       description: |
-        Bank transfer processing (empty body), VAN transfer simulation (`type` virtual + transfers), or verification
-        directive simulation (`type` customer-verification, customer link, and errorCode). Typed bodies are mutually
-        exclusive; omit the body or send `{}` / null only for bank processing.
+        Bank transfer processing (omit body or `{}`), VAN transfer simulation (`type` virtual + transfers), or
+        verification directive simulation (`type` customer-verification, customer link, and errorCode). Typed bodies
+        are mutually exclusive; use only an omitted body or `{}` for bank processing.
       oneOf:
         - $ref: '#/components/schemas/SandboxSimulationVirtualAccountTransfersRequest'
         - $ref: '#/components/schemas/SandboxSimulationCustomerVerificationRequest'

--- a/openapi.yml
+++ b/openapi.yml
@@ -8545,9 +8545,9 @@ paths:
     post:
       tags:
         - sandbox simulations
-      summary: Sandbox simulations (bank transfer processing or VAN transfers)
+      summary: Sandbox simulations (bank transfers, VAN transfers, or customer verification directives)
       description: |
-        Sandbox-only endpoint with two modes:
+        Sandbox-only endpoint with three modes:
 
         **Simulate bank transfer processing** — Omit the body or send an empty JSON object. Processes or fails
         the last 500 bank transfers on the authorized application or Sandbox account (and initiated micro-deposits).
@@ -8556,6 +8556,12 @@ paths:
 
         **Simulate VAN (virtual) transfers** — Send a JSON body with `type` set to `virtual` and a `transfers`
         array (up to 10 items). External transfers are created and processed immediately. Returns **202 Accepted**.
+
+        **Simulate verification directives** — For a business Verified Customer in **`retry`** or **`document`**
+        status, send `type`: `customer-verification`, `_links.customer.href` pointing at that customer, and
+        `errorCode` set to one of: `PersonalIDRequired`, `POBoxNotAllowed`, `AddressNotAssociatedWithBusiness`,
+        `EINDocumentRequired`. Returns **200** with HAL `_links.self` and `errorCode`. Then **GET** the Customer;
+        the same code appears in `_embedded.errors` for end-to-end testing.
       operationId: simulateBankTransferProcessing
       x-speakeasy-name-override: simulate
       x-codeSamples:
@@ -8571,7 +8577,8 @@ paths:
         required: false
         description: |
           Optional. Use an empty object (or omit the body) for bank transfer processing. For VAN simulation,
-          send `type`: `virtual` and a `transfers` array (see schema).
+          send `type`: `virtual` and a `transfers` array. For verification directives, send `type`:
+          `customer-verification`, `_links.customer`, and `errorCode` (see schema).
         content:
           application/vnd.dwolla.v1.hal+json:
             schema:
@@ -8579,19 +8586,33 @@ paths:
       responses:
         '200':
           description: |
-            Bank transfer processing simulation completed. Pending bank transfers and micro-deposits were
-            processed or failed.
+            Success. **Bank transfer processing** returns HAL with `total`. **Customer verification directives**
+            return HAL `_links.self` and `errorCode` (retrieve the Customer for `_embedded.errors`).
           content:
             application/vnd.dwolla.v1.hal+json:
               schema:
-                $ref: '#/components/schemas/SandboxSimulationBankProcessingResponse'
-              example:
-                _links:
-                  self:
-                    href: https://api-sandbox.dwolla.com/sandbox-simulations
-                    type: application/vnd.dwolla.v1.hal+json
-                    resource-type: sandbox-simulation
-                total: 8
+                oneOf:
+                  - $ref: '#/components/schemas/SandboxSimulationBankProcessingResponse'
+                  - $ref: '#/components/schemas/SandboxSimulationCustomerVerificationResponse'
+              examples:
+                bankTransferProcessing:
+                  summary: Bank transfer processing
+                  value:
+                    _links:
+                      self:
+                        href: https://api-sandbox.dwolla.com/sandbox-simulations
+                        type: application/vnd.dwolla.v1.hal+json
+                        resource-type: sandbox-simulation
+                    total: 8
+                customerVerificationDirective:
+                  summary: Customer verification directive simulation
+                  value:
+                    _links:
+                      self:
+                        href: https://api-sandbox.dwolla.com/sandbox-simulations
+                        type: application/vnd.dwolla.v1.hal+json
+                        resource-type: sandbox-simulation
+                    errorCode: AddressNotAssociatedWithBusiness
         '202':
           description: |
             Accepted. Virtual (VAN) transfer simulation: requested transfers were accepted for immediate
@@ -15956,19 +15977,6 @@ components:
           type: integer
           format: int32
           example: 1
-    SandboxSimulationBankProcessingRequest:
-      title: SandboxSimulationBankProcessingRequest
-      description: |
-        Omit the body, send JSON null, or an empty JSON object. Triggers processing (or failure) for the last
-        500 bank transfers on the authorized application or Sandbox account, and initiated micro-deposits.
-        Successful response is 200 with a HAL body including total.
-      oneOf:
-        - title: SandboxSimulationBankProcessingEmptyObject
-          description: Empty JSON object.
-          type: object
-          additionalProperties: false
-        - type: 'null'
-          description: JSON null body (uncommon).
     SandboxSimulationVirtualTransferItem:
       title: SandboxSimulationVirtualTransferItem
       description: One simulated external (VAN) transfer in a sandbox-simulations request.
@@ -15994,8 +16002,8 @@ components:
                   example: https://api-sandbox.dwolla.com/funding-sources/5880e310-675a-4ce3-87d9-a475cc565e09
         amount:
           $ref: '#/components/schemas/TransferAmount'
-    SandboxSimulationVirtualRequest:
-      title: SandboxSimulationVirtualRequest
+    SandboxSimulationVirtualAccountTransfersRequest:
+      title: SandboxSimulationVirtualAccountTransfersRequest
       description: |
         Simulate Virtual Account Number (VAN) / external transfers in Sandbox. Up to 10 transfers per request;
         transfers are created and processed immediately. Successful response is 202 Accepted.
@@ -16015,14 +16023,69 @@ components:
           maxItems: 10
           items:
             $ref: '#/components/schemas/SandboxSimulationVirtualTransferItem'
+    SandboxSimulationCustomerVerificationRequest:
+      title: SandboxSimulationCustomerVerificationRequest
+      description: |
+        Simulate a verification directive for a business Verified Customer in Sandbox. The customer must be in
+        `retry` or `document` status. After a successful call, retrieve the Customer resource; the given `errorCode`
+        appears under `_embedded.errors`. See Dwolla documentation for verification directive meanings.
+      type: object
+      required:
+        - type
+        - _links
+        - errorCode
+      properties:
+        type:
+          type: string
+          const: customer-verification
+          description: Must be set to customer-verification for verification directive simulation.
+        _links:
+          type: object
+          required:
+            - customer
+          properties:
+            customer:
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+                  format: uri
+                  description: URL of the Sandbox customer to attach the simulated directive to.
+                  example: https://api-sandbox.dwolla.com/customers/00000000-0000-0000-0000-000000000000
+        errorCode:
+          type: string
+          description: Verification directive to simulate for the linked customer.
+          enum:
+            - PersonalIDRequired
+            - POBoxNotAllowed
+            - AddressNotAssociatedWithBusiness
+            - EINDocumentRequired
+          example: AddressNotAssociatedWithBusiness
+    SandboxSimulationBankProcessingRequest:
+      title: SandboxSimulationBankProcessingRequest
+      description: |
+        Omit the body, send JSON null, or an empty JSON object. Triggers processing (or failure) for the last
+        500 bank transfers on the authorized application or Sandbox account, and initiated micro-deposits.
+        Successful response is 200 with a HAL body including total.
+      oneOf:
+        - title: SandboxSimulationBankProcessingEmptyObject
+          description: Empty JSON object.
+          type: object
+          additionalProperties: false
+        - type: 'null'
+          description: JSON null body (uncommon).
     SandboxSimulationRequest:
       title: SandboxSimulationRequest
       description: |
-        Bank transfer processing (empty body) or VAN transfer simulation (type virtual + transfers).
-        Use an empty object or omit the body for bank processing; use a virtual payload for VAN simulation.
+        Bank transfer processing (empty body), VAN transfer simulation (`type` virtual + transfers), or verification
+        directive simulation (`type` customer-verification, customer link, and errorCode). Typed bodies are mutually
+        exclusive; omit the body or send `{}` / null only for bank processing.
       oneOf:
+        - $ref: '#/components/schemas/SandboxSimulationVirtualAccountTransfersRequest'
+        - $ref: '#/components/schemas/SandboxSimulationCustomerVerificationRequest'
         - $ref: '#/components/schemas/SandboxSimulationBankProcessingRequest'
-        - $ref: '#/components/schemas/SandboxSimulationVirtualRequest'
     SandboxSimulationBankProcessingResponse:
       title: SandboxSimulationBankProcessingResponse
       description: Response when simulating bank transfer processing (200 OK).
@@ -16043,6 +16106,32 @@ components:
           properties:
             self:
               $ref: '#/components/schemas/HalLink'
+    SandboxSimulationCustomerVerificationResponse:
+      title: SandboxSimulationCustomerVerificationResponse
+      description: |
+        Response when simulating customer verification directives (200 OK). Echoes the simulated `errorCode`;
+        retrieve the Customer resource to inspect `_embedded.errors`.
+      type: object
+      required:
+        - _links
+        - errorCode
+      properties:
+        _links:
+          type: object
+          required:
+            - self
+          properties:
+            self:
+              $ref: '#/components/schemas/HalLink'
+        errorCode:
+          type: string
+          description: Verification directive that was simulated.
+          enum:
+            - PersonalIDRequired
+            - POBoxNotAllowed
+            - AddressNotAssociatedWithBusiness
+            - EINDocumentRequired
+          example: AddressNotAssociatedWithBusiness
     ExchangePartner:
       title: ExchangePartner
       type: object

--- a/specs/resources/customers/retrieveUpdateCustomer.yml
+++ b/specs/resources/customers/retrieveUpdateCustomer.yml
@@ -52,6 +52,7 @@ get:
               - $ref: '../../schemas/customers/Customer.yml#/UnverifiedCustomer'
               - $ref: '../../schemas/customers/Customer.yml#/ReceiveOnlyCustomer'
               - $ref: '../../schemas/customers/Customer.yml#/VerifiedPersonalCustomer'
+              - $ref: '../../schemas/customers/Customer.yml#/VerifiedSolePropCustomer'
               - $ref: '../../schemas/customers/Customer.yml#/VerifiedBusinessCustomer'
     '403':
       description: forbidden

--- a/specs/resources/sandbox-simulations.yml
+++ b/specs/resources/sandbox-simulations.yml
@@ -32,9 +32,8 @@ post:
   requestBody:
     required: false
     description: |
-      Optional. Use an empty object (or omit the body) for bank transfer processing. For VAN simulation,
-      send `type`: `virtual` and a `transfers` array. For verification directives, send `type`:
-      `customer-verification`, `_links.customer`, and `errorCode` (see schema).
+      Optional. For bank transfer processing, omit the body or send `{}`. For VAN simulation, send `type`: `virtual` and a `transfers` array. For verification
+      directives, send `type`: `customer-verification`, `_links.customer`, and `errorCode` (see schema).
     content:
       application/vnd.dwolla.v1.hal+json:
         schema:
@@ -73,6 +72,13 @@ post:
       description: |
         Accepted. Virtual (VAN) transfer simulation: requested transfers were accepted for immediate
         processing in Sandbox.
+    '400':
+      description: |
+        Bad Request.
+      content:
+        application/vnd.dwolla.v1.hal+json:
+          schema:
+            $ref: '../schemas/common.yml#/components/schemas/BadRequestError'
     '401':
       description: unauthorized
       content:

--- a/specs/resources/sandbox-simulations.yml
+++ b/specs/resources/sandbox-simulations.yml
@@ -1,9 +1,9 @@
 post:
   tags:
     - sandbox simulations
-  summary: Sandbox simulations (bank transfer processing or VAN transfers)
+  summary: Sandbox simulations (bank transfers, VAN transfers, or customer verification directives)
   description: |
-    Sandbox-only endpoint with two modes:
+    Sandbox-only endpoint with three modes:
 
     **Simulate bank transfer processing** — Omit the body or send an empty JSON object. Processes or fails
     the last 500 bank transfers on the authorized application or Sandbox account (and initiated micro-deposits).
@@ -12,6 +12,12 @@ post:
 
     **Simulate VAN (virtual) transfers** — Send a JSON body with `type` set to `virtual` and a `transfers`
     array (up to 10 items). External transfers are created and processed immediately. Returns **202 Accepted**.
+
+    **Simulate verification directives** — For a business Verified Customer in **`retry`** or **`document`**
+    status, send `type`: `customer-verification`, `_links.customer.href` pointing at that customer, and
+    `errorCode` set to one of: `PersonalIDRequired`, `POBoxNotAllowed`, `AddressNotAssociatedWithBusiness`,
+    `EINDocumentRequired`. Returns **200** with HAL `_links.self` and `errorCode`. Then **GET** the Customer;
+    the same code appears in `_embedded.errors` for end-to-end testing.
   operationId: simulateBankTransferProcessing
   x-speakeasy-name-override: simulate
   x-codeSamples:
@@ -27,7 +33,8 @@ post:
     required: false
     description: |
       Optional. Use an empty object (or omit the body) for bank transfer processing. For VAN simulation,
-      send `type`: `virtual` and a `transfers` array (see schema).
+      send `type`: `virtual` and a `transfers` array. For verification directives, send `type`:
+      `customer-verification`, `_links.customer`, and `errorCode` (see schema).
     content:
       application/vnd.dwolla.v1.hal+json:
         schema:
@@ -35,19 +42,33 @@ post:
   responses:
     '200':
       description: |
-        Bank transfer processing simulation completed. Pending bank transfers and micro-deposits were
-        processed or failed.
+        Success. **Bank transfer processing** returns HAL with `total`. **Customer verification directives**
+        return HAL `_links.self` and `errorCode` (retrieve the Customer for `_embedded.errors`).
       content:
         application/vnd.dwolla.v1.hal+json:
           schema:
-            $ref: '../schemas/sandbox/SandboxSimulations.yml#/SandboxSimulationBankProcessingResponse'
-          example:
-            _links:
-              self:
-                href: https://api-sandbox.dwolla.com/sandbox-simulations
-                type: application/vnd.dwolla.v1.hal+json
-                resource-type: sandbox-simulation
-            total: 8
+            oneOf:
+              - $ref: '../schemas/sandbox/SandboxSimulations.yml#/SandboxSimulationBankProcessingResponse'
+              - $ref: '../schemas/sandbox/SandboxSimulations.yml#/SandboxSimulationCustomerVerificationResponse'
+          examples:
+            bankTransferProcessing:
+              summary: Bank transfer processing
+              value:
+                _links:
+                  self:
+                    href: https://api-sandbox.dwolla.com/sandbox-simulations
+                    type: application/vnd.dwolla.v1.hal+json
+                    resource-type: sandbox-simulation
+                total: 8
+            customerVerificationDirective:
+              summary: Customer verification directive simulation
+              value:
+                _links:
+                  self:
+                    href: https://api-sandbox.dwolla.com/sandbox-simulations
+                    type: application/vnd.dwolla.v1.hal+json
+                    resource-type: sandbox-simulation
+                errorCode: AddressNotAssociatedWithBusiness
     '202':
       description: |
         Accepted. Virtual (VAN) transfer simulation: requested transfers were accepted for immediate

--- a/specs/resources/sandbox-simulations.yml
+++ b/specs/resources/sandbox-simulations.yml
@@ -1,11 +1,17 @@
 post:
   tags:
     - sandbox simulations
-  summary: Simulate bank transfer processing (Sandbox only)
+  summary: Sandbox simulations (bank transfer processing or VAN transfers)
   description: |
-    Triggers processing for the last 500 bank transfers on the authorized application or Sandbox account. This endpoint is only available in the Sandbox environment. It will process or fail pending bank-to-bank transactions (including both sides of a transfer when applicable) and initiated micro-deposits. If webhooks are configured, corresponding events will be delivered.
+    Sandbox-only endpoint with two modes:
 
-    If a bank-to-bank transaction is initiated between two users, call this endpoint twice to process both the debit and credit sides.
+    **Simulate bank transfer processing** — Omit the body or send an empty JSON object. Processes or fails
+    the last 500 bank transfers on the authorized application or Sandbox account (and initiated micro-deposits).
+    If webhooks are configured, events are delivered. If a bank-to-bank transaction involves two users,
+    call this twice to process debit and credit sides. Returns **200** with a HAL document including `total`.
+
+    **Simulate VAN (virtual) transfers** — Send a JSON body with `type` set to `virtual` and a `transfers`
+    array (up to 10 items). External transfers are created and processed immediately. Returns **202 Accepted**.
   operationId: simulateBankTransferProcessing
   x-speakeasy-name-override: simulate
   x-codeSamples:
@@ -19,18 +25,33 @@ post:
     - $ref: '../schemas/common.yml#/components/parameters/Accept'
   requestBody:
     required: false
-    description: Optional JSON body. Typically empty; presence of body is not required.
+    description: |
+      Optional. Use an empty object (or omit the body) for bank transfer processing. For VAN simulation,
+      send `type`: `virtual` and a `transfers` array (see schema).
     content:
       application/vnd.dwolla.v1.hal+json:
         schema:
-          type: object
+          $ref: '../schemas/sandbox/SandboxSimulations.yml#/SandboxSimulationRequest'
   responses:
     '200':
-      description: Simulation executed. Pending bank transfers and micro-deposits were processed or failed.
+      description: |
+        Bank transfer processing simulation completed. Pending bank transfers and micro-deposits were
+        processed or failed.
       content:
         application/vnd.dwolla.v1.hal+json:
           schema:
-            type: object
+            $ref: '../schemas/sandbox/SandboxSimulations.yml#/SandboxSimulationBankProcessingResponse'
+          example:
+            _links:
+              self:
+                href: https://api-sandbox.dwolla.com/sandbox-simulations
+                type: application/vnd.dwolla.v1.hal+json
+                resource-type: sandbox-simulation
+            total: 8
+    '202':
+      description: |
+        Accepted. Virtual (VAN) transfer simulation: requested transfers were accepted for immediate
+        processing in Sandbox.
     '401':
       description: unauthorized
       content:
@@ -57,4 +78,3 @@ post:
               message:
                 type: string
                 example: Not authorized to simulate transfer processing.
-

--- a/specs/schemas/sandbox/SandboxSimulations.yml
+++ b/specs/schemas/sandbox/SandboxSimulations.yml
@@ -24,8 +24,8 @@ SandboxSimulationVirtualTransferItem:
     amount:
       $ref: '../common.yml#/components/schemas/TransferAmount'
 
-SandboxSimulationVirtualRequest:
-  title: SandboxSimulationVirtualRequest
+SandboxSimulationVirtualAccountTransfersRequest:
+  title: SandboxSimulationVirtualAccountTransfersRequest
   description: |
     Simulate Virtual Account Number (VAN) / external transfers in Sandbox. Up to 10 transfers per request;
     transfers are created and processed immediately. Successful response is 202 Accepted.
@@ -46,6 +46,47 @@ SandboxSimulationVirtualRequest:
       items:
         $ref: './SandboxSimulations.yml#/SandboxSimulationVirtualTransferItem'
 
+SandboxSimulationCustomerVerificationRequest:
+  title: SandboxSimulationCustomerVerificationRequest
+  description: |
+    Simulate a verification directive for a business Verified Customer in Sandbox. The customer must be in
+    `retry` or `document` status. After a successful call, retrieve the Customer resource; the given `errorCode`
+    appears under `_embedded.errors`. See Dwolla documentation for verification directive meanings.
+  type: object
+  required:
+    - type
+    - _links
+    - errorCode
+  properties:
+    type:
+      type: string
+      const: customer-verification
+      description: Must be set to customer-verification for verification directive simulation.
+    _links:
+      type: object
+      required:
+        - customer
+      properties:
+        customer:
+          type: object
+          required:
+            - href
+          properties:
+            href:
+              type: string
+              format: uri
+              description: URL of the Sandbox customer to attach the simulated directive to.
+              example: https://api-sandbox.dwolla.com/customers/00000000-0000-0000-0000-000000000000
+    errorCode:
+      type: string
+      description: Verification directive to simulate for the linked customer.
+      enum:
+        - PersonalIDRequired
+        - POBoxNotAllowed
+        - AddressNotAssociatedWithBusiness
+        - EINDocumentRequired
+      example: AddressNotAssociatedWithBusiness
+
 SandboxSimulationBankProcessingRequest:
   title: SandboxSimulationBankProcessingRequest
   description: |
@@ -63,11 +104,40 @@ SandboxSimulationBankProcessingRequest:
 SandboxSimulationRequest:
   title: SandboxSimulationRequest
   description: |
-    Bank transfer processing (empty body) or VAN transfer simulation (type virtual + transfers).
-    Use an empty object or omit the body for bank processing; use a virtual payload for VAN simulation.
+    Bank transfer processing (empty body), VAN transfer simulation (`type` virtual + transfers), or verification
+    directive simulation (`type` customer-verification, customer link, and errorCode). Typed bodies are mutually
+    exclusive; omit the body or send `{}` / null only for bank processing.
   oneOf:
+    - $ref: './SandboxSimulations.yml#/SandboxSimulationVirtualAccountTransfersRequest'
+    - $ref: './SandboxSimulations.yml#/SandboxSimulationCustomerVerificationRequest'
     - $ref: './SandboxSimulations.yml#/SandboxSimulationBankProcessingRequest'
-    - $ref: './SandboxSimulations.yml#/SandboxSimulationVirtualRequest'
+
+SandboxSimulationCustomerVerificationResponse:
+  title: SandboxSimulationCustomerVerificationResponse
+  description: |
+    Response when simulating customer verification directives (200 OK). Echoes the simulated `errorCode`;
+    retrieve the Customer resource to inspect `_embedded.errors`.
+  type: object
+  required:
+    - _links
+    - errorCode
+  properties:
+    _links:
+      type: object
+      required:
+        - self
+      properties:
+        self:
+          $ref: '../common.yml#/components/schemas/HalLink'
+    errorCode:
+      type: string
+      description: Verification directive that was simulated.
+      enum:
+        - PersonalIDRequired
+        - POBoxNotAllowed
+        - AddressNotAssociatedWithBusiness
+        - EINDocumentRequired
+      example: AddressNotAssociatedWithBusiness
 
 SandboxSimulationBankProcessingResponse:
   title: SandboxSimulationBankProcessingResponse

--- a/specs/schemas/sandbox/SandboxSimulations.yml
+++ b/specs/schemas/sandbox/SandboxSimulations.yml
@@ -1,0 +1,91 @@
+SandboxSimulationVirtualTransferItem:
+  title: SandboxSimulationVirtualTransferItem
+  description: One simulated external (VAN) transfer in a sandbox-simulations request.
+  type: object
+  required:
+    - _link
+    - amount
+  properties:
+    _link:
+      type: object
+      description: Link wrapper for the destination funding source (Dwolla HAL-style single link).
+      required:
+        - destination
+      properties:
+        destination:
+          type: object
+          required:
+            - href
+          properties:
+            href:
+              type: string
+              format: uri
+              example: https://api-sandbox.dwolla.com/funding-sources/5880e310-675a-4ce3-87d9-a475cc565e09
+    amount:
+      $ref: '../common.yml#/components/schemas/TransferAmount'
+
+SandboxSimulationVirtualRequest:
+  title: SandboxSimulationVirtualRequest
+  description: |
+    Simulate Virtual Account Number (VAN) / external transfers in Sandbox. Up to 10 transfers per request;
+    transfers are created and processed immediately. Successful response is 202 Accepted.
+  type: object
+  required:
+    - type
+    - transfers
+  properties:
+    type:
+      type: string
+      const: virtual
+      description: Must be set to virtual for VAN transfer simulation.
+    transfers:
+      type: array
+      description: Transfers to simulate (max 10 per request).
+      minItems: 1
+      maxItems: 10
+      items:
+        $ref: './SandboxSimulations.yml#/SandboxSimulationVirtualTransferItem'
+
+SandboxSimulationBankProcessingRequest:
+  title: SandboxSimulationBankProcessingRequest
+  description: |
+    Omit the body, send JSON null, or an empty JSON object. Triggers processing (or failure) for the last
+    500 bank transfers on the authorized application or Sandbox account, and initiated micro-deposits.
+    Successful response is 200 with a HAL body including total.
+  oneOf:
+    - title: SandboxSimulationBankProcessingEmptyObject
+      description: Empty JSON object.
+      type: object
+      additionalProperties: false
+    - type: 'null'
+      description: JSON null body (uncommon).
+
+SandboxSimulationRequest:
+  title: SandboxSimulationRequest
+  description: |
+    Bank transfer processing (empty body) or VAN transfer simulation (type virtual + transfers).
+    Use an empty object or omit the body for bank processing; use a virtual payload for VAN simulation.
+  oneOf:
+    - $ref: './SandboxSimulations.yml#/SandboxSimulationBankProcessingRequest'
+    - $ref: './SandboxSimulations.yml#/SandboxSimulationVirtualRequest'
+
+SandboxSimulationBankProcessingResponse:
+  title: SandboxSimulationBankProcessingResponse
+  description: Response when simulating bank transfer processing (200 OK).
+  type: object
+  required:
+    - _links
+    - total
+  properties:
+    total:
+      type: integer
+      format: int32
+      example: 8
+      description: Count of bank transfers (and related items) affected by the simulation run.
+    _links:
+      type: object
+      required:
+        - self
+      properties:
+        self:
+          $ref: '../common.yml#/components/schemas/HalLink'

--- a/specs/schemas/sandbox/SandboxSimulations.yml
+++ b/specs/schemas/sandbox/SandboxSimulations.yml
@@ -90,23 +90,18 @@ SandboxSimulationCustomerVerificationRequest:
 SandboxSimulationBankProcessingRequest:
   title: SandboxSimulationBankProcessingRequest
   description: |
-    Omit the body, send JSON null, or an empty JSON object. Triggers processing (or failure) for the last
+    Omit the request body or send an empty JSON object (`{}`). Triggers processing (or failure) for the last
     500 bank transfers on the authorized application or Sandbox account, and initiated micro-deposits.
     Successful response is 200 with a HAL body including total.
-  oneOf:
-    - title: SandboxSimulationBankProcessingEmptyObject
-      description: Empty JSON object.
-      type: object
-      additionalProperties: false
-    - type: 'null'
-      description: JSON null body (uncommon).
+  type: object
+  additionalProperties: false
 
 SandboxSimulationRequest:
   title: SandboxSimulationRequest
   description: |
-    Bank transfer processing (empty body), VAN transfer simulation (`type` virtual + transfers), or verification
-    directive simulation (`type` customer-verification, customer link, and errorCode). Typed bodies are mutually
-    exclusive; omit the body or send `{}` / null only for bank processing.
+    Bank transfer processing (omit body or `{}`), VAN transfer simulation (`type` virtual + transfers), or
+    verification directive simulation (`type` customer-verification, customer link, and errorCode). Typed bodies
+    are mutually exclusive; use only an omitted body or `{}` for bank processing.
   oneOf:
     - $ref: './SandboxSimulations.yml#/SandboxSimulationVirtualAccountTransfersRequest'
     - $ref: './SandboxSimulations.yml#/SandboxSimulationCustomerVerificationRequest'


### PR DESCRIPTION
Updates the Dwolla OpenAPI source so bundled specs and generated clients match real Sandbox and customer payloads.

- **POST** `/sandbox-simulations`

  - Replaces bare `type: object` request/response with explicit schemas in `specs/schemas/sandbox/SandboxSimulations.yml` and wires them from `specs/resources/sandbox-simulations.yml`.
  - Documents three behaviors:
    - **Bank transfer processing** — 
      - **request**: omit body, {}, or JSON null; 
      - **response**: 200 HAL with _links.self and total.
    - **VAN / virtual transfers** — 
      - **request**: type: virtual and transfers (1–10 items); 
      - **response**: 202 Accepted.
    - **Customer verification directives** — 
      - **request**: type: customer-verification, _links.customer.href, and errorCode (PersonalIDRequired, POBoxNotAllowed, AddressNotAssociatedWithBusiness, EINDocumentRequired) for business verified customers in retry or document; 
      - **response**: 200 HAL with _links.self and errorCode (clients should still GET the customer for _embedded.errors).
  - 200 response body is modeled as oneOf the bank-processing response and the customer-verification response so total-only vs errorCode-only shapes stay distinct without inventing a shared empty body.
  - Adds named response examples for bank processing and verification directives.

- **GET**  `/customers/{id}`

  - Adds `VerifiedSolePropCustomer` to the 200 `oneOf` before VerifiedBusinessCustomer in `specs/resources/customers/retrieveUpdateCustomer.yml`, aligned with list/update customer schemas, so sole proprietorship customers validate instead of being forced through the controller-based business schema.

**Follow-up:**  regenerate downstream SDKs from the updated bundle